### PR TITLE
fix: clear clippy lints and two latent correctness bugs

### DIFF
--- a/src/bin/01.rs
+++ b/src/bin/01.rs
@@ -21,7 +21,7 @@ mode (`cargo script`).
 fn number_line(line: &str) -> u32 {
     let mut chars = line.chars().filter_map(|c| c.to_digit(10));
     let start = chars.next().unwrap();
-    let end = chars.last().unwrap_or(start);
+    let end = chars.next_back().unwrap_or(start);
     10 * start + end
 }
 

--- a/src/bin/04.rs
+++ b/src/bin/04.rs
@@ -23,7 +23,7 @@ impl FromStr for Card {
     type Err = FailedReadError;
 
     fn from_str(line: &str) -> Result<Self, Self::Err> {
-        let data = line.split(':').last().ok_or(FailedReadError)?;
+        let data = line.split(':').next_back().ok_or(FailedReadError)?;
         let mut groups = data.split('|');
         let winning_str = groups.next().ok_or(FailedReadError)?.trim();
         let numbers_str = groups.next().ok_or(FailedReadError)?.trim();
@@ -90,7 +90,7 @@ Card 5: 87 83 26 28 32 | 88 30 70 12 93 22 82 36
 Card 6: 31 18 13 56 72 | 74 77 10 23 35 67 36 11";
 
     #[test]
-    fn test_03() {
+    fn test_04() {
         let cards: Vec<Card> = INPUT.lines().map(|x| x.parse().unwrap()).collect();
         assert_eq!(cards.len(), 6);
         assert_eq!(cards[0].winning.len(), 5);

--- a/src/bin/05.rs
+++ b/src/bin/05.rs
@@ -97,7 +97,7 @@ fn read<'a>(lines: impl Iterator<Item = &'a str>) -> (Vec<u64>, AllMappers) {
         .next()
         .unwrap()
         .split(':')
-        .last()
+        .next_back()
         .unwrap()
         .split_whitespace()
         .map(|x| x.parse().unwrap())
@@ -121,7 +121,7 @@ fn read<'a>(lines: impl Iterator<Item = &'a str>) -> (Vec<u64>, AllMappers) {
 
 fn seeds_as_ranges_brute_force(seeds: &[u64]) -> impl Iterator<Item = u64> + '_ {
     let pairs = seeds.iter().step_by(2).zip(seeds.iter().skip(1).step_by(2));
-    let seeds = pairs.map(|(from, len)| (*from..*from + *len));
+    let seeds = pairs.map(|(from, len)| *from..*from + *len);
     seeds.flatten()
 }
 

--- a/src/bin/06.rs
+++ b/src/bin/06.rs
@@ -29,7 +29,7 @@ impl Race {
 fn get_arr(string: &str) -> Vec<u64> {
     string
         .split(':')
-        .last()
+        .next_back()
         .unwrap()
         .trim()
         .split_ascii_whitespace()

--- a/src/bin/08.rs
+++ b/src/bin/08.rs
@@ -61,7 +61,6 @@ fn follow_directions_syml(directions: &str, nodes: &HashMap<String, (String, Str
         .filter(|x| x.ends_with('A'))
         .map(|x| &x[..])
         .collect();
-    println!("{current_nodes:?}");
     for direction in directions.chars().cycle() {
         match direction {
             'L' => current_nodes.iter_mut().for_each(|x| *x = &nodes[*x].0),

--- a/src/bin/09.rs
+++ b/src/bin/09.rs
@@ -17,7 +17,7 @@ fn read(input: &str) -> impl Iterator<Item = Vec<i64>> + '_ {
 
 fn compute_next(data: &[i64]) -> i64 {
     let next_vec: Vec<_> = data.windows(2).map(|x| x[1] - x[0]).collect();
-    let next = if next_vec.iter().sum::<i64>() == 0 {
+    let next = if next_vec.iter().all(|&x| x == 0) {
         0
     } else {
         compute_next(&next_vec)
@@ -27,7 +27,7 @@ fn compute_next(data: &[i64]) -> i64 {
 
 fn compute_previous(data: &[i64]) -> i64 {
     let next_vec: Vec<_> = data.windows(2).map(|x| x[1] - x[0]).collect();
-    let previous = if next_vec.iter().sum::<i64>() == 0 {
+    let previous = if next_vec.iter().all(|&x| x == 0) {
         0
     } else {
         compute_previous(&next_vec)

--- a/src/bin/10.rs
+++ b/src/bin/10.rs
@@ -107,7 +107,7 @@ impl Cursor {
 
         let mut valid_dirs = Direction::iter().filter(|dir| {
             log::debug!("{self:?} {dir:?}");
-            self.peek(grid, *dir).map_or(false, |next| {
+            self.peek(grid, *dir).is_some_and(|next| {
                 log::debug!("Checking ({next}, {dir:?})");
                 matches!(
                     (next, dir),
@@ -221,7 +221,7 @@ fn compute_and_print_grid(strs: &[&str]) -> (usize, usize) {
     }
 
     let internal: usize = inside.iter().map(|x| usize::from(*x)).sum();
-    (((count + 1) / 2), internal)
+    (count.div_ceil(2), internal)
 }
 
 fn main() {

--- a/src/bin/14.rs
+++ b/src/bin/14.rs
@@ -106,7 +106,6 @@ fn tilt_dir(grid: &mut Grid<Map>, dir: Direction) {
 
 fn compute(text: &str) -> Num {
     let mut grid = read_data(text);
-    println!();
     tilt_dir(&mut grid, Direction::North);
     compute_load(&grid)
 }
@@ -114,7 +113,7 @@ fn compute(text: &str) -> Num {
 fn compute_cycles(text: &str, cycles: usize) -> Num {
     let mut grid = read_data(text);
     let mut cache: Vec<Grid<Map>> = Vec::new();
-    while !cache.iter().any(|x| *x == grid) {
+    while !cache.contains(&grid) {
         cache.push(grid.clone());
         tilt_cycle(&mut grid);
     }

--- a/src/bin/16.rs
+++ b/src/bin/16.rs
@@ -146,7 +146,7 @@ fn compute2(text: &str) -> usize {
         ));
         max = max.max(count_energize(
             &grid,
-            &Position::new(i, isize::try_from(grid.rows()).unwrap() - 1),
+            &Position::new(i, isize::try_from(grid.cols()).unwrap() - 1),
             Direction::Left,
         ));
     }
@@ -154,7 +154,7 @@ fn compute2(text: &str) -> usize {
         max = max.max(count_energize(&grid, &Position::new(0, i), Direction::Down));
         max = max.max(count_energize(
             &grid,
-            &Position::new(isize::try_from(grid.cols()).unwrap() - 1, i),
+            &Position::new(isize::try_from(grid.rows()).unwrap() - 1, i),
             Direction::Up,
         ));
     }

--- a/src/bin/20.rs
+++ b/src/bin/20.rs
@@ -159,14 +159,12 @@ fn read_input(text: &str) -> ModuleGraph {
 
     // Set up Conj nodes
     for node in graph.node_indices() {
-        let module = &graph[node].module;
-        let mut edges: Vec<NodeIndex> = Vec::new();
-        if let Module::Conjunction { .. } = module {
-            edges = graph.neighbors_directed(node, Incoming).collect();
-        }
-        if !edges.is_empty() {
-            let module = &mut graph[node].module;
-            *module = Module::Conjunction(edges.iter().map(|k| (*k, Pulse::Low)).collect());
+        if let Module::Conjunction(_) = &graph[node].module {
+            let edges = graph
+                .neighbors_directed(node, Incoming)
+                .map(|k| (k, Pulse::Low))
+                .collect();
+            graph[node].module = Module::Conjunction(edges);
         }
     }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Cleanup pass from a review for bugs, performance, simplifications, and modernizations. This PR covers the safe, high-confidence batch; the remaining judgment-call items are tracked in a follow-up issue.

## Correctness
- **09** — recursion base case was `next_vec.iter().sum() == 0`, which stops early on rows like `[2, -2]` that sum to zero without being flat. Now `all(|&x| x == 0)`. Latent on real AoC input, correct in general.
- **16** — `compute2` indexed the right-edge start with `rows()-1` as a *column* and the bottom-edge start with `cols()-1` as a *row*. Harmless on square grids, wrong otherwise. Axes swapped.

## Modernizations (`cargo clippy --all` now clean on 1.96)
- `.last()` → `.next_back()` on double-ended iterators (01, 04, 05, 06)
- `map_or(false, …)` → `is_some_and`, `(n + 1) / 2` → `div_ceil` (10)
- `iter().any(|x| *x == g)` → `contains` (14)
- collapse the flag-driven Conjunction setup into a single `if let` (20)

## Cruft
- drop stray debug `println!` that fired on every run including tests (08, 14)
- rename misnamed `test_03` → `test_04` (04)

Verified: `cargo test` (all pass), `cargo clippy --all` (0 warnings), `cargo fmt`.