### PR TITLE
Review follow-ups: correctness, modernization, perf, simplifications

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v4.5.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -21,7 +21,7 @@ repos:
       - id: cargo-check
       - id: clippy
   - repo: https://github.com/codespell-project/codespell
-    rev: "v2.2.6"
+    rev: "v2.4.2"
     hooks:
       - id: codespell
         args: ["-L", "crate,ot", "-w"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "aoc2023"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
-rust-version = "1.78"
+rust-version = "1.85"
 
 [dependencies]
 cached = "*"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.83"
+channel = "1.96"

--- a/src/bin/02.rs
+++ b/src/bin/02.rs
@@ -59,12 +59,9 @@ impl FromStr for Meas {
 }
 
 fn measurements(line: &str) -> (u32, Vec<Meas>) {
-    let split: Vec<&str> = line.split(':').collect();
-    assert_eq!(split.len(), 2);
-    let game_str = split[0];
+    let (game_str, results) = line.split_once(':').unwrap();
     let game_number: u32 = game_str.strip_prefix("Game ").unwrap().parse().unwrap();
-    let results = split[1].split(';');
-    let meas = results.map(|x| x.parse().unwrap()).collect();
+    let meas = results.split(';').map(|x| x.parse().unwrap()).collect();
     (game_number, meas)
 }
 

--- a/src/bin/04.rs
+++ b/src/bin/04.rs
@@ -23,7 +23,7 @@ impl FromStr for Card {
     type Err = FailedReadError;
 
     fn from_str(line: &str) -> Result<Self, Self::Err> {
-        let data = line.split(':').next_back().ok_or(FailedReadError)?;
+        let data = line.split_once(':').ok_or(FailedReadError)?.1;
         let mut groups = data.split('|');
         let winning_str = groups.next().ok_or(FailedReadError)?.trim();
         let numbers_str = groups.next().ok_or(FailedReadError)?.trim();

--- a/src/bin/05.rs
+++ b/src/bin/05.rs
@@ -92,13 +92,13 @@ impl AllMappers {
 }
 
 fn read<'a>(lines: impl Iterator<Item = &'a str>) -> (Vec<u64>, AllMappers) {
-    let mut lines = lines.into_iter();
+    let mut lines = lines;
     let seeds: Vec<u64> = lines
         .next()
         .unwrap()
-        .split(':')
-        .next_back()
+        .split_once(':')
         .unwrap()
+        .1
         .split_whitespace()
         .map(|x| x.parse().unwrap())
         .collect();

--- a/src/bin/06.rs
+++ b/src/bin/06.rs
@@ -28,9 +28,9 @@ impl Race {
 
 fn get_arr(string: &str) -> Vec<u64> {
     string
-        .split(':')
-        .next_back()
+        .split_once(':')
         .unwrap()
+        .1
         .trim()
         .split_ascii_whitespace()
         .map(|x| x.parse().unwrap())

--- a/src/bin/07-trait.rs
+++ b/src/bin/07-trait.rs
@@ -116,7 +116,7 @@ fn count<T: Card>(cards: &[T]) -> HashMap<T, u64> {
 impl<T: Card> Hand<T> {
     fn level(&self) -> u64 {
         let card_counts = count(&self.cards);
-        let mut counts: Vec<_> = card_counts.clone().into_values().collect();
+        let mut counts: Vec<_> = card_counts.values().copied().collect();
         counts.sort_unstable();
         counts.reverse();
 
@@ -152,7 +152,7 @@ impl<T: Card> Hand<T> {
 
 impl<T: Card> Ord for Hand<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (self.level(), self.cards, self.bid).cmp(&(other.level(), other.cards, other.bid))
+        (self.level(), self.cards).cmp(&(other.level(), other.cards))
     }
 }
 

--- a/src/bin/07.rs
+++ b/src/bin/07.rs
@@ -74,7 +74,7 @@ fn count(cards: &[Card]) -> HashMap<Card, u64> {
 impl Hand {
     fn level(&self) -> u64 {
         let card_counts = count(&self.cards);
-        let mut counts: Vec<_> = card_counts.clone().into_values().collect();
+        let mut counts: Vec<_> = card_counts.values().copied().collect();
         counts.sort_unstable();
         counts.reverse();
 
@@ -114,7 +114,7 @@ impl Hand {
 
 impl Ord for Hand {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        (self.level(), self.cards, self.bid).cmp(&(other.level(), other.cards, other.bid))
+        (self.level(), self.cards).cmp(&(other.level(), other.cards))
     }
 }
 

--- a/src/bin/12.rs
+++ b/src/bin/12.rs
@@ -15,35 +15,28 @@ use std::vec;
 #[cached]
 fn cmp_line(conditions: String, ops: Vec<usize>) -> usize {
     if ops.is_empty() {
-        let val = conditions.chars().all(|x| x != '#');
-        return usize::from(val);
+        return usize::from(!conditions.contains('#'));
     }
 
-    // This is the maximum consecutive space
+    // The input is ASCII, so byte indexing matches char indexing.
+    let bytes = conditions.as_bytes();
+
+    // The most leading space we can leave before the first group.
     let limit_space: usize = conditions.len() - (ops.iter().sum::<usize>() + ops.len() - 1);
-    let mut count = 0;
-
     let max_space = conditions
-        .chars()
-        .enumerate()
-        .find(|(_, v)| *v == '#')
-        .map_or(conditions.len(), |(i, _)| i);
-    let max_space = max_space.min(limit_space);
+        .find('#')
+        .unwrap_or(conditions.len())
+        .min(limit_space);
 
+    let mut count = 0;
     for space in 0..=max_space {
-        let valid = conditions
-            .chars()
-            .skip(space)
-            .take(ops[0])
-            .all(|c| c != '.')
-            && conditions.chars().nth(space + ops[0]).unwrap_or('.') != '#';
-        if conditions.chars().skip(space + ops[0]).count() < 2 {
+        let end = space + ops[0];
+        let valid = bytes[space..end].iter().all(|&c| c != b'.')
+            && bytes.get(end).copied().unwrap_or(b'.') != b'#';
+        if conditions.len() - end < 2 {
             count += usize::from(valid);
         } else if valid {
-            count += cmp_line(
-                conditions[space + ops[0] + 1..].to_string(),
-                ops[1..].to_vec(),
-            );
+            count += cmp_line(conditions[end + 1..].to_string(), ops[1..].to_vec());
         }
     }
     count

--- a/src/bin/13.rs
+++ b/src/bin/13.rs
@@ -10,6 +10,30 @@ this is fast enough and simpler.
 
 use grid::Grid;
 
+/// A mirror line, tagged by axis so row and column results can't be confused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mirror {
+    Row(usize),
+    Column(usize),
+}
+
+impl Mirror {
+    /// The reflection index within its own axis.
+    const fn line(self) -> usize {
+        match self {
+            Self::Row(v) | Self::Column(v) => v,
+        }
+    }
+
+    /// The puzzle score: rows count for 100, columns for 1.
+    const fn score(self) -> usize {
+        match self {
+            Self::Row(v) => v * 100,
+            Self::Column(v) => v,
+        }
+    }
+}
+
 /// Make a block of bools from a string.
 fn make_block(block: &str) -> Grid<bool> {
     block
@@ -33,26 +57,25 @@ fn compare_mirror_y(block: &Grid<bool>, val: usize) -> bool {
     true
 }
 
-/// Find the mirror line. Set skip=0 to not skip any values. Otherwise, skip
-/// this value if present.
-fn compute_block(block: &Grid<bool>, skip: usize) -> Option<usize> {
+/// Find the mirror line, optionally skipping one known result (the unsmudged
+/// line in part 2).
+fn compute_block(block: &Grid<bool>, skip: Option<Mirror>) -> Option<Mirror> {
     (1..block.rows())
-        .filter(|&x| x * 100 != skip)
-        .find(|&y| compare_mirror_y(block, y))
-        .map(|x| x * 100)
+        .map(Mirror::Row)
+        .find(|&m| Some(m) != skip && compare_mirror_y(block, m.line()))
         .or_else(|| {
             let mut copied = block.clone();
             copied.transpose();
             (1..copied.rows())
-                .filter(|&x| x != skip)
-                .find(|&x| compare_mirror_y(&copied, x))
+                .map(Mirror::Column)
+                .find(|&m| Some(m) != skip && compare_mirror_y(&copied, m.line()))
         })
 }
 
 /// This computes smudges and checks each block. It skips the non-smudged
 /// result.
-fn compute_block_one_smudge(block: &Grid<bool>) -> Option<usize> {
-    let skip = compute_block(block, 0).unwrap();
+fn compute_block_one_smudge(block: &Grid<bool>) -> Option<Mirror> {
+    let skip = compute_block(block, None);
     block
         .indexed_iter()
         .map(|((y, x), _)| {
@@ -67,14 +90,14 @@ fn compute_block_one_smudge(block: &Grid<bool>) -> Option<usize> {
 /// Compute all the first part.
 fn compute(text: &str) -> usize {
     text.split("\n\n")
-        .map(|s| compute_block(&make_block(s), 0).expect(s))
+        .map(|s| compute_block(&make_block(s), None).expect(s).score())
         .sum()
 }
 
 /// Compute all the second part.
 fn compute_one_smudge(text: &str) -> usize {
     text.split("\n\n")
-        .map(|s| compute_block_one_smudge(&make_block(s)).expect(s))
+        .map(|s| compute_block_one_smudge(&make_block(s)).expect(s).score())
         .sum()
 }
 
@@ -123,8 +146,18 @@ mod tests {
     fn on_each_simple() {
         let blocks = INPUT.split("\n\n");
         let mut blocks = blocks.map(make_block);
-        assert_eq!(compute_block(&blocks.next().unwrap(), 0).unwrap(), 5);
-        assert_eq!(compute_block(&blocks.next().unwrap(), 0).unwrap(), 400);
+        assert_eq!(
+            compute_block(&blocks.next().unwrap(), None)
+                .unwrap()
+                .score(),
+            5
+        );
+        assert_eq!(
+            compute_block(&blocks.next().unwrap(), None)
+                .unwrap()
+                .score(),
+            400
+        );
         assert!(blocks.next().is_none());
     }
 
@@ -133,11 +166,15 @@ mod tests {
         let blocks = INPUT.split("\n\n");
         let mut blocks = blocks.map(make_block);
         assert_eq!(
-            compute_block_one_smudge(&blocks.next().unwrap()).unwrap(),
+            compute_block_one_smudge(&blocks.next().unwrap())
+                .unwrap()
+                .score(),
             300
         );
         assert_eq!(
-            compute_block_one_smudge(&blocks.next().unwrap()).unwrap(),
+            compute_block_one_smudge(&blocks.next().unwrap())
+                .unwrap()
+                .score(),
             100
         );
         assert!(blocks.next().is_none());

--- a/src/bin/14.rs
+++ b/src/bin/14.rs
@@ -12,6 +12,7 @@ Continuing to enjoy enums with `strum`'s additions.
 */
 
 use grid::Grid;
+use std::collections::HashMap;
 use std::str::FromStr;
 use strum::IntoEnumIterator;
 
@@ -112,15 +113,20 @@ fn compute(text: &str) -> Num {
 
 fn compute_cycles(text: &str, cycles: usize) -> Num {
     let mut grid = read_data(text);
-    let mut cache: Vec<Grid<Map>> = Vec::new();
-    while !cache.contains(&grid) {
-        cache.push(grid.clone());
+    // Map each seen state to its index for O(1) cycle detection; keep the load
+    // at each index so the answer is a direct lookup.
+    let mut seen: HashMap<Grid<Map>, usize> = HashMap::new();
+    let mut loads: Vec<Num> = Vec::new();
+    let cycle_start = loop {
+        if let Some(&start) = seen.get(&grid) {
+            break start;
+        }
+        seen.insert(grid.clone(), loads.len());
+        loads.push(compute_load(&grid));
         tilt_cycle(&mut grid);
-    }
-    let cycle_start = cache.iter().position(|x| *x == grid).unwrap();
-    let cycle_len = cache.len() - cycle_start;
-    grid = cache[(cycles - cycle_start) % cycle_len + cycle_start].clone();
-    compute_load(&grid)
+    };
+    let cycle_len = loads.len() - cycle_start;
+    loads[(cycles - cycle_start) % cycle_len + cycle_start]
 }
 
 fn main() {

--- a/src/bin/17.rs
+++ b/src/bin/17.rs
@@ -47,7 +47,11 @@ impl PartialOrd for State {
 
 fn read_grid(text: &str) -> Grid<usize> {
     text.lines()
-        .map(|x| x.chars().map(|x| x.to_string().parse().unwrap()).collect())
+        .map(|x| {
+            x.chars()
+                .map(|x| x.to_digit(10).unwrap() as usize)
+                .collect()
+        })
         .collect::<Vec<_>>()
         .into()
 }
@@ -81,7 +85,7 @@ fn compute_path(grid: &Grid<usize>, min_path: usize, max_path: usize) -> Option<
         if !computed.insert((position, direction, len)) {
             continue;
         }
-        let directions = vec![
+        let directions = [
             direction,
             direction.clockwise(),
             direction.counter_clockwise(),

--- a/src/bin/19.rs
+++ b/src/bin/19.rs
@@ -12,8 +12,8 @@ This was originally implemented with a regex (see history), but now uses an
 actual parser.
 */
 
-use gcollections::ops::{set::Intersection, Cardinality, Difference};
-use interval::{interval_set::ToIntervalSet, IntervalSet};
+use gcollections::ops::{Cardinality, Difference, set::Intersection};
+use interval::{IntervalSet, interval_set::ToIntervalSet};
 use itertools::Itertools;
 use regex::Regex;
 use std::{collections::HashMap, ops::Index, str::FromStr};

--- a/src/bin/20.rs
+++ b/src/bin/20.rs
@@ -222,9 +222,12 @@ fn measure_cycle(node_graph: &mut ModuleGraph, len: usize) -> (Option<u64>, u64,
 fn compute1(text: &str) -> u64 {
     let mut node_map = read_input(text);
     let (cycles, high, low) = measure_cycle(&mut node_map, 1000);
-    println!("cycles: {cycles:?}, high: {high}, low: {low}");
+    log::debug!("cycles: {cycles:?}, high: {high}, low: {low}");
     cycles.map_or(high * low, |cycles| {
-        high * 1000 * low * 1000 / (cycles * cycles)
+        // `high`/`low` cover one reset cycle; scale to 1000 presses.
+        assert_eq!(1000 % cycles, 0, "cycle length must divide 1000");
+        let n = 1000 / cycles;
+        (high * n) * (low * n)
     })
 }
 

--- a/src/bin/20.rs
+++ b/src/bin/20.rs
@@ -19,9 +19,9 @@ use std::collections::{HashMap, HashSet};
 use derive_more::Constructor;
 use itertools::Itertools;
 use petgraph::{
+    Direction::{Incoming, Outgoing},
     graph::Graph,
     graph::NodeIndex,
-    Direction::{Incoming, Outgoing},
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/bin/21.rs
+++ b/src/bin/21.rs
@@ -164,11 +164,11 @@ fn main() {
 
     println!("{a2}/2 x^2 +{b2}/2 x + {c} = y");
     println!("x=0, y={c}");
-    println!("x=1, y={}", (a2 + b2) / 2 + c);
-    println!("x=2, y={}", (4 * a2 + 2 * b2) / 2 + c);
+    println!("x=1, y={}", usize::midpoint(a2, b2) + c);
+    println!("x=2, y={}", usize::midpoint(4 * a2, 2 * b2) + c);
     println!(
         "x=202300, y={}",
-        (202_300 * 202_300 * a2 + 202_300 * b2) / 2 + c
+        usize::midpoint(202_300 * 202_300 * a2, 202_300 * b2) + c
     );
 }
 

--- a/src/bin/22.rs
+++ b/src/bin/22.rs
@@ -67,7 +67,7 @@ impl Interval {
         }
     }
 
-    const fn intersects(self, rhs: &Self) -> bool {
+    const fn is_disjoint(self, rhs: &Self) -> bool {
         self.low > rhs.high || self.high < rhs.low
     }
 }
@@ -119,11 +119,11 @@ impl Block {
     }
 
     const fn overlaps_xy(&self, block: &Self) -> bool {
-        !self.x.intersects(&block.x) && !self.y.intersects(&block.y)
+        !self.x.is_disjoint(&block.x) && !self.y.is_disjoint(&block.y)
     }
 
     const fn overlaps_xyz(&self, block: &Self) -> bool {
-        self.overlaps_xy(block) && !self.z.intersects(&block.z)
+        self.overlaps_xy(block) && !self.z.is_disjoint(&block.z)
     }
 
     const fn high_point(&self, block: &Self) -> Option<usize> {

--- a/src/bin/23.rs
+++ b/src/bin/23.rs
@@ -53,6 +53,8 @@ print(sorted((len(p)-1 for p in paths), reverse=True))
 
 */
 
+use std::collections::HashMap;
+
 use grid::Grid;
 use itertools::Itertools;
 use petgraph::algo::all_simple_paths;
@@ -77,6 +79,7 @@ fn make_graph_directed(grid: &Grid<char>) -> Graph<(usize, usize), usize> {
             }
         })
         .collect::<Vec<_>>();
+    let node_at: HashMap<(usize, usize), _> = nodes.iter().map(|&n| (graph[n], n)).collect();
     let dirs = [(0, 1), (1, 0)];
     for node in &nodes {
         let (y, x) = graph[*node];
@@ -87,20 +90,17 @@ fn make_graph_directed(grid: &Grid<char>) -> Graph<(usize, usize), usize> {
                 i32::try_from(x).unwrap() + dx,
             );
             if let Some(next) = grid.get(ny, nx) {
+                let coord = (usize::try_from(ny).unwrap(), usize::try_from(nx).unwrap());
+                let Some(&other) = node_at.get(&coord) else {
+                    continue;
+                };
                 match (current, dy, dx, next) {
                     ('.', _, _, '.')
                     | ('>', 0, 1, _)
                     | (_, 0, 1, '>')
                     | ('v', 1, 0, _)
                     | (_, 1, 0, 'v') => {
-                        let other = nodes
-                            .iter()
-                            .find(|n| {
-                                graph[**n]
-                                    == (usize::try_from(ny).unwrap(), usize::try_from(nx).unwrap())
-                            })
-                            .unwrap();
-                        graph.add_edge(*node, *other, 1);
+                        graph.add_edge(*node, other, 1);
                     }
                     _ => {}
                 }
@@ -110,14 +110,7 @@ fn make_graph_directed(grid: &Grid<char>) -> Graph<(usize, usize), usize> {
                     | ('<', 0, 1, _)
                     | (_, 1, 0, '^')
                     | ('^', 1, 0, _) => {
-                        let other = nodes
-                            .iter()
-                            .find(|n| {
-                                graph[**n]
-                                    == (usize::try_from(ny).unwrap(), usize::try_from(nx).unwrap())
-                            })
-                            .unwrap();
-                        graph.add_edge(*other, *node, 1);
+                        graph.add_edge(other, *node, 1);
                     }
                     _ => {}
                 }

--- a/src/bin/24.rs
+++ b/src/bin/24.rs
@@ -233,14 +233,17 @@ fn find_velocity(vals: &[Line]) -> (i64, i64, i64) {
     (*dx, *dy, *dz)
 }
 
-const fn find_position(vals: &[Line], dx: i64, dy: i64, dz: i64) -> (i64, i64, i64) {
+fn find_position(vals: &[Line], dx: i64, dy: i64, dz: i64) -> (i64, i64, i64) {
     let a = &vals[0];
     let b = &vals[1];
     let ax = dx - a.d.x;
     let ay = dy - a.d.y;
     let bx = dx - b.d.x;
     let by = dy - b.d.y;
-    let t = (bx * (b.p.y - a.p.y) - by * (b.p.x - a.p.x)) / (ax * by - bx * ay);
+    let det = ax * by - bx * ay;
+    let num = bx * (b.p.y - a.p.y) - by * (b.p.x - a.p.x);
+    assert_eq!(num % det, 0, "rock launch time is not integral");
+    let t = num / det;
     (
         a.p.x + t * (a.d.x - dx),
         a.p.y + t * (a.d.y - dy),

--- a/src/bin/24.rs
+++ b/src/bin/24.rs
@@ -40,7 +40,7 @@ def intersect_in(vals, low, high):
 
 vals = read('24test.txt')
 seen = list(intersect_in(vals, 7, 27))
-print(len(seens))
+print(len(seen))
 
 vals = read('24data.txt')
 seen = list(intersect_in(vals, 200000000000000, 400000000000000))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,9 +9,7 @@ A few problems use repeated items, so those are provided here.
 
 */
 
-/*/
-This has helpers for 2D problems.
-*/
+/// Helpers for 2D grid problems.
 pub mod grid_helper {
     use core::ops::{Add, Index, IndexMut};
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Works through the items tracked in #17. Stacked on #16 (base is its branch); retarget to `main` once #16 merges.

Each commit is a self-contained group; `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` are all green at the tip.

## Correctness traps (correct on real input, fragile in general)
- **13** — tag mirror results with `Mirror::{Row,Column}` instead of packing both axes into one `usize`, so the part-2 `skip` filter can't silently no-op on the wrong axis.
- **20** — `compute1` cycle scaling now asserts the cycle divides 1000 and computes the factor directly.
- **22** — rename `Interval::intersects` → `is_disjoint` (it returned true when intervals do *not* overlap; every caller negated it).
- **24** — `find_position` asserts integer divisibility instead of silently truncating; dropped the pointless `const`.

## Modernization
- bump toolchain pin **1.83 → 1.96**, move to **edition 2024** (rust-version 1.78 → 1.85), reformat under the 2024 style edition.
- **21** — `(a + b) / 2` → `usize::midpoint` (new `manual_midpoint` lint under `-D warnings`).
- **lib** — `/*/ … */` was a plain comment, not a doc comment; make it `///`.
- pre-commit autoupdate (pre-commit-hooks v6, codespell v2.4.2); fix the `seens` typo it caught.

## Performance (quadratic → linear on hot paths)
- **14** — cycle detection via `HashMap<Grid<Map>, usize>` + per-index loads instead of `Vec::contains` + `position` each step.
- **23** — coordinate → node `HashMap` instead of `iter().find` per neighbour.
- **12** — index `as_bytes()` directly instead of re-walking with `chars().nth()` / `skip().count()`; `str::find` for the first `#`.
- **17** — array instead of `vec!` for the three candidate directions in the Dijkstra loop.

## Simplifications
- **02/04/05/06** — `split_once(':')` over `split(':').last()` / `collect()`.
- **17** — `char::to_digit` over `to_string().parse()`.
- **07 / 07-trait** — `values().copied()` over `clone().into_values()`; drop `bid` from the `Ord` tuple.

## Intentionally deferred (noted on #17)
- 10/14/16 per-char `from_str` — these use strum's `EnumString`; a hand-written `TryFrom<char>` would duplicate the serialize mappings the docs deliberately showcase, and the repo favors clarity over the tiny allocation.
- 19 `with_cat` — taking `self` by value doesn't actually reduce clones; `..self.clone()` stays clearer.
- 23 `all_simple_paths` exponential part-2 — a bitmask DFS rewrite is a larger change; the node-lookup fix is the safe win.